### PR TITLE
updates to files

### DIFF
--- a/assets/javascript/logic.js
+++ b/assets/javascript/logic.js
@@ -56,9 +56,14 @@ function eventsResult (results) {
         var date = $("<p>").html(eventObject.date);
         var city = $("<p>").html(eventObject.city + ", " + eventObject.state);
         var image = $("<img>").attr("src", eventObject.image);
-        var info = $("<p>").html(eventObject.info);
 
-        image.attr("style", "width: 300px");
+        // info line
+        var info = $("<p>").html(eventObject.info);
+        // change info width
+        info.attr("style", "width: 300px"); 
+
+        // possibly change width of images, but may appear too big in details page
+        image.attr("style", "width: 600px"); 
 
         var eventDiv = $("<div>"); // THIS IS THE DIV FOR EACH EVENT RESULT
         var eventDisplay = $("#display");

--- a/details_page.html
+++ b/details_page.html
@@ -108,7 +108,9 @@
       </div>
     </div>  
     
-    <div id="event-display" class="card-body"></div>
+    <div class="card-body" id="event-display" >
+     
+    </div>    
 
     <!-- Row for searching events -->
     <div class="row">


### PR DESCRIPTION
Hey guys, I modified the results display on the index page to show only a list of the events with a little scroll bar on the side. I think it looks better than having so many repeated images there. When you click on the events, you can still see the image for that event on the details page (and I reduced the size for that one too).



HOWEVER, I committed my work just now and I don't see it here on this branch... so please do not merge this with the master. I can show you what I did tomorrow evening.
![update_to_index_details_results](https://user-images.githubusercontent.com/46850059/54807830-b978e480-4c3b-11e9-8816-aad53e1821a2.png)
